### PR TITLE
Fix network policies ingress rules are never considered.

### DIFF
--- a/pkg/controller/rules.go
+++ b/pkg/controller/rules.go
@@ -112,9 +112,6 @@ func ingressRulesForNetworkPolicy(np networkingv1.NetworkPolicy) []string {
 	if ingress == nil {
 		return nil
 	}
-	if np.ObjectMeta.Namespace != "" {
-		return nil
-	}
 	rules := []string{}
 	for _, i := range ingress {
 		allow := []string{}


### PR DESCRIPTION
Closes #3.

It would also be possible to just read network policies from a certain namespace, but I am not sure if this would be counter-intuitive because the function for creating egress rules for network policies does not have such a filtering.

This would fix the problem for the time being, I guess, but it will not resolve issues when contradicting rules are deployed by a user. Same for the egress part.

A way to make this more user-friendly in the future would be resolving issue #2. 