### PR TITLE
Increase logging rate limit

### DIFF
--- a/pkg/controller/nftable.go
+++ b/pkg/controller/nftable.go
@@ -23,6 +23,6 @@ const nftableTemplateIpv4 = `table ip firewall {
 		{{- end }}
 
 		counter comment "count dropped packets"
-		limit rate 2/minute counter packets 1 bytes 40 log prefix "nftables-firewall-dropped: "
+		limit rate 10/second counter packets 1 bytes 40 log prefix "nftables-firewall-dropped: "
 	}
 }`


### PR DESCRIPTION
Increase the logging rate-limit for drops in the firewall table to increase visibility while still not overloading machines with log messages.